### PR TITLE
makefiles for Code and Code\Library clean targets

### DIFF
--- a/Code/Library/Makefile
+++ b/Code/Library/Makefile
@@ -70,4 +70,5 @@ libaurora.a :: write_potential.h write_potential.c
 	ranlib libaurora.a
 	rm -f write_potential.o
 
-
+clean:
+	rm -f *.o libaurora.a

--- a/Code/Makefile
+++ b/Code/Makefile
@@ -87,3 +87,7 @@ eview: eview.c
 	$(CC) $(LFLAGS) -L$(LIB) eview.c -o eview \
 	-lGL -lGLU /System/Library/Frameworks/GLUT.framework/GLUT -lobjc
 
+clean:
+	rm -f eview pot2volc pot2ppm pot2alpha pot2energy pot_interp \
+	slicer expose fraw2ppm e2ppm e2ppmB e2ppmS e2ppmBS sp2ppm bench_dep bench_trilerp \
+	ppmcrop gamma oldfraw2ppm energy2ppm


### PR DESCRIPTION
- fix stackdestory and fscanf warnings; replace comments with if 0 endif; fix gitignore
- image prog links
- Makefiles now have a clean target in /Code and /Code/Library.
